### PR TITLE
Fix example code in doc comment

### DIFF
--- a/src/lib.mo
+++ b/src/lib.mo
@@ -196,7 +196,7 @@ module {
     /// Example:
     /// ```motoko
     /// import Prng "mo:prng"; 
-    /// let rng = Prng.SFC32(); 
+    /// let rng = Prng.SFC32a(); 
     /// rng.init(0);
     /// ``` 
     public func init(seed : Nat32) = init3(seed, seed, seed);


### PR DESCRIPTION
The comment for SFC32.init used the constructor SFC32() which requires parameters instead of the function SFC32a()