### PR TITLE
mops benchmark; bump base dependency;

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ mops test
 
 ## Benchmarks
 
+### Mops benchmark
+
+Run
+```
+mops bench --replica pocket-ic
+```
+
+### Canister profiling
+
 The benchmarking code can be found here: [canister-profiling](https://github.com/research-ag/canister-profiling)
 The values below were measured with moc 0.11.1 and dfx 0.20.1.
 

--- a/bench/prng.bench.mo
+++ b/bench/prng.bench.mo
@@ -1,0 +1,53 @@
+import Array "mo:base/Array";
+import Bench "mo:bench";
+import Iter "mo:base/Iter";
+import Nat "mo:base/Nat";
+import Prim "mo:prim";
+import Text "mo:base/Text";
+
+import Prng "../src";
+
+module {
+
+  public func init() : Bench.Bench {
+    let bench = Bench.Bench();
+
+    bench.name("Prng");
+    bench.description("Benchmark N `next` calls for different PRNG methods");
+
+    let rows = [
+      "Seiran128",
+      "SFC64",
+      "SFC32",
+    ];
+
+    let cols = [
+      "10",
+      "100",
+      "1000",
+      "10000",
+    ];
+
+    bench.rows(rows);
+    bench.cols(cols);
+
+    let methods : [{ next : () -> Any }] = [
+      Prng.Seiran128(),
+      Prng.SFC64a(),
+      Prng.SFC32a(),
+    ];
+
+    bench.runner(
+      func(row, col) {
+        let ?ri = Array.indexOf<Text>(row, rows, Text.equal) else Prim.trap("Cannot determine row: " # row);
+        let ?n = Nat.fromText(col) else Prim.trap("Cannot parse N");
+        let method = methods[ri];
+        for (i in Iter.range(1, n)) {
+          ignore method.next();
+        };
+      }
+    );
+
+    bench;
+  };
+};

--- a/bench/prng.bench.mo
+++ b/bench/prng.bench.mo
@@ -41,9 +41,9 @@ module {
       func(row, col) {
         let ?ri = Array.indexOf<Text>(row, rows, Text.equal) else Prim.trap("Cannot determine row: " # row);
         let ?n = Nat.fromText(col) else Prim.trap("Cannot parse N");
-        let method = methods[ri];
+        let next = methods[ri].next;
         for (i in Iter.range(1, n)) {
-          ignore method.next();
+          ignore next();
         };
       }
     );

--- a/mops.toml
+++ b/mops.toml
@@ -7,11 +7,13 @@ keywords = [ "rand", "random", "rng", "sfc", "seiran" ]
 license = "Apache-2.0"
 
 [dependencies]
-base = "0.11.1"
+base = "0.11.3"
 
 [dev-dependencies]
+bench = "1.0.0"
 test = "2.0.0"
 matchers = "https://github.com/kritzcreek/motoko-matchers#v1.3.0@3dac8a071b69e4e651b25a7d9683fe831eb7cffd"
 
 [toolchain]
-moc = "0.11.1"
+moc = "0.11.3"
+pocket-ic = "1.0.0"


### PR DESCRIPTION
Mops benchmark results:

```
Prng

Benchmark N `next` calls for different PRNG methods


Instructions

|           |    10 |    100 |    1000 |     10000 |
| :-------- | ----: | -----: | ------: | --------: |
| Seiran128 | 4_027 | 23_788 | 219_319 | 2_172_550 |
| SFC64     | 5_240 | 35_850 | 337_532 | 3_353_331 |
| SFC32     | 5_271 | 32_472 | 301_577 | 2_997_508 |
```