### PR TITLE
Allocation-free version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Prng changelog
 
+## 0.2.0
+
+- Allocation free version
+
 ## 0.1.1
 
 - Add documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.2.0
 
-- Allocation free version
+- Allocation-free version
+- `next()` only allocates for the returned value
+- **Breaking:** State representation changed
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Wasm instructions per invocation of `next()`.
 
 | method | Seiran128 | SFC64 | SFC32 |
 | ------ | --------- | ----- | ----- |
-| next   | 167       | 320   | 270   |
+| next   | 382       | 754   | 380   |
 
 ### Memory
 
@@ -133,7 +133,7 @@ Heap allocation per invocation of `next()`.
 
 | method | Seiran128 | SFC64 | SFC32 |
 | ------ | --------- | ----- | ----- |
-| next   | 35        | 47    | 16    |
+| next   | 12        | 12    | 4    |
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Heap allocation per invocation of `next()`.
 
 | method | Seiran128 | SFC64 | SFC32 |
 | ------ | --------- | ----- | ----- |
-| next   | 12        | 12    | 4    |
+| next   | 12        | 12    | 4     |
 
 ## Copyright
 

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prng"
-version = "0.1.1"
+version = "0.2.0"
 description = "Statistical pseudo-random number generators"
 repository = "https://github.com/research-ag/prng"
 keywords = [ "rand", "random", "rng", "sfc", "seiran" ]

--- a/src/SFC32.mo
+++ b/src/SFC32.mo
@@ -19,13 +19,30 @@
 /// Main author: Timo Hanke (timohanke)
 /// Contributors: Andy Gura (AndyGura), react0r-com
 
+import Prim "mo:prim";
+
 module SFC32 {
+  let nat8To16 = Prim.nat8ToNat16;
+  let nat16To32 = Prim.nat16ToNat32;
+  let nat32To16 = Prim.nat32ToNat16;
+
   /// State of an SFC 32-bit generator.
-  /// Layout: `[a, b, c, d, p, q, r]`
-  public type SFC32 = [var Nat32];
+  /// Layout: state words `a`, `b`, `c`, `d` occupy slots `[0..1]`, `[2..3]`,
+  /// `[4..5]`, `[6..7]` respectively — each split little-endian into two
+  /// `Nat16` slots, with the lowest 16 bits at the lower index. Tuning
+  /// parameters `p`, `q`, `r` live in slots `[8]`, `[9]`, `[10]` as raw
+  /// `Nat16` values (they only need to fit shift amounts ≤ 32).
+  public type SFC32 = [var Nat16];
 
   /// Default seed for SFC32 generators.
   public let defaultSFC32Seed : Nat32 = 0xbeef5eed;
+
+  // Split a Nat32 into two little-endian Nat16 slots starting at `base`.
+  // Used only on the init cold path; `next` inlines packing via `explodeNat32`.
+  func writeU32(self : SFC32, base : Nat, v : Nat32) {
+    self[base] := nat32To16(v & 0xFFFF);
+    self[base + 1] := nat32To16(v >> 16);
+  };
 
   /// Constructs an SFC 32-bit generator.
   /// The recommended constructor arguments are:
@@ -44,7 +61,10 @@ module SFC32 {
   /// let rng = Prng.SFC32.SFC32a();
   /// ```
   public func new(p : Nat32, q : Nat32, r : Nat32, seed : (implicit : (defaultSFC32Seed : Nat32))) : SFC32 {
-    let prng : SFC32 = [var 0, 0, 0, 0, p, q, r];
+    let p16 = nat32To16(p & 0xFFFF);
+    let q16 = nat32To16(q & 0xFFFF);
+    let r16 = nat32To16(r & 0xFFFF);
+    let prng : SFC32 = [var 0, 0, 0, 0, 0, 0, 0, 0, p16, q16, r16];
     prng.init(seed);
     prng;
   };
@@ -68,10 +88,10 @@ module SFC32 {
   /// rng.init3(0, 1, 2);
   /// ```
   public func init3(self : SFC32, seed1 : Nat32, seed2 : Nat32, seed3 : Nat32) {
-    self[0] := seed1;
-    self[1] := seed2;
-    self[2] := seed3;
-    self[3] := 1;
+    writeU32(self, 0, seed1);
+    writeU32(self, 2, seed2);
+    writeU32(self, 4, seed3);
+    writeU32(self, 6, 1);
 
     var i_ : Nat8 = 12;
     while (i_ > 0) {
@@ -89,17 +109,34 @@ module SFC32 {
   /// rng.next(); // -> 1_363_572_419
   /// ```
   public func next(self : SFC32) : Nat32 {
-    let a = self[0];
-    let b = self[1];
-    let c = self[2];
-    let d = self[3];
+    let a = nat16To32(self[0]) | (nat16To32(self[1]) << 16);
+    let b = nat16To32(self[2]) | (nat16To32(self[3]) << 16);
+    let c = nat16To32(self[4]) | (nat16To32(self[5]) << 16);
+    let d = nat16To32(self[6]) | (nat16To32(self[7]) << 16);
+
+    let p = nat16To32(self[8]);
+    let q = nat16To32(self[9]);
+    let r = nat16To32(self[10]);
 
     let result = a +% b +% d;
 
-    self[0] := b ^ (b >> self[5]);
-    self[1] := c +% (c << self[6]);
-    self[2] := (c <<> self[4]) +% result;
-    self[3] := d +% 1;
+    let na = b ^ (b >> q);
+    let nb = c +% (c << r);
+    let nc = (c <<> p) +% result;
+    let nd = d +% 1;
+
+    let (a0, a1, a2, a3) = Prim.explodeNat32(na);
+    let (b0, b1, b2, b3) = Prim.explodeNat32(nb);
+    let (c0, c1, c2, c3) = Prim.explodeNat32(nc);
+    let (d0, d1, d2, d3) = Prim.explodeNat32(nd);
+    self[0] := nat8To16(a2) << 8 | nat8To16(a3);
+    self[1] := nat8To16(a0) << 8 | nat8To16(a1);
+    self[2] := nat8To16(b2) << 8 | nat8To16(b3);
+    self[3] := nat8To16(b0) << 8 | nat8To16(b1);
+    self[4] := nat8To16(c2) << 8 | nat8To16(c3);
+    self[5] := nat8To16(c0) << 8 | nat8To16(c1);
+    self[6] := nat8To16(d2) << 8 | nat8To16(d3);
+    self[7] := nat8To16(d0) << 8 | nat8To16(d1);
 
     result;
   };

--- a/src/SFC64.mo
+++ b/src/SFC64.mo
@@ -18,13 +18,34 @@
 /// Main author: Timo Hanke (timohanke)
 /// Contributors: Andy Gura (AndyGura), react0r-com
 
+import Prim "mo:prim";
+
 module SFC64 {
+  let nat8To16 = Prim.nat8ToNat16;
+  let nat16To32 = Prim.nat16ToNat32;
+  let nat32To16 = Prim.nat32ToNat16;
+  let nat32To64 = Prim.nat32ToNat64;
+  let nat64To32 = Prim.nat64ToNat32;
+
   /// State of an SFC 64-bit generator.
-  /// Layout: `[a, b, c, d, p, q, r]`
-  public type SFC64 = [var Nat64];
+  /// Layout: state words `a`, `b`, `c`, `d` occupy slots `[0..3]`, `[4..7]`,
+  /// `[8..11]`, `[12..15]` respectively — each split little-endian into four
+  /// `Nat16` slots, with the lowest 16 bits at the lower index. Tuning
+  /// parameters `p`, `q`, `r` live in slots `[16]`, `[17]`, `[18]` as raw
+  /// `Nat16` values (they only need to fit shift amounts ≤ 64).
+  public type SFC64 = [var Nat16];
 
   /// Default seed for SFC64 generators.
   public let defaultSFC64Seed : Nat64 = 0xcafef00dbeef5eed;
+
+  // Split a Nat64 into four little-endian Nat16 slots starting at `base`.
+  // Used only on the init cold path; `next` inlines packing via `explodeNat64`.
+  func writeU64(self : SFC64, base : Nat, v : Nat64) {
+    self[base] := nat32To16(nat64To32(v & 0xFFFF));
+    self[base + 1] := nat32To16(nat64To32((v >> 16) & 0xFFFF));
+    self[base + 2] := nat32To16(nat64To32((v >> 32) & 0xFFFF));
+    self[base + 3] := nat32To16(nat64To32(v >> 48));
+  };
 
   /// Constructs an SFC 64-bit generator.
   /// The recommended constructor arguments are: 24, 11, 3.
@@ -41,7 +62,10 @@ module SFC64 {
   /// let rng = Prng.SFC64.SFC64a();
   /// ```
   public func new(p : Nat64, q : Nat64, r : Nat64, seed : (implicit : (defaultSFC64Seed : Nat64))) : SFC64 {
-    let prng : SFC64 = [var 0, 0, 0, 0, p, q, r];
+    let p16 = nat32To16(nat64To32(p & 0xFFFF));
+    let q16 = nat32To16(nat64To32(q & 0xFFFF));
+    let r16 = nat32To16(nat64To32(r & 0xFFFF));
+    let prng : SFC64 = [var 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, p16, q16, r16];
     prng.init(seed);
     prng;
   };
@@ -65,10 +89,10 @@ module SFC64 {
   /// rng.init3(0, 1, 2);
   /// ```
   public func init3(self : SFC64, seed1 : Nat64, seed2 : Nat64, seed3 : Nat64) {
-    self[0] := seed1;
-    self[1] := seed2;
-    self[2] := seed3;
-    self[3] := 1;
+    writeU64(self, 0, seed1);
+    writeU64(self, 4, seed2);
+    writeU64(self, 8, seed3);
+    writeU64(self, 12, 1);
 
     var i_ : Nat8 = 12;
     while (i_ > 0) {
@@ -86,17 +110,42 @@ module SFC64 {
   /// rng.next(); // -> 4_237_781_876_154_851_393
   /// ```
   public func next(self : SFC64) : Nat64 {
-    let a = self[0];
-    let b = self[1];
-    let c = self[2];
-    let d = self[3];
+    let a = nat32To64(nat16To32(self[0])) | (nat32To64(nat16To32(self[1])) << 16) | (nat32To64(nat16To32(self[2])) << 32) | (nat32To64(nat16To32(self[3])) << 48);
+    let b = nat32To64(nat16To32(self[4])) | (nat32To64(nat16To32(self[5])) << 16) | (nat32To64(nat16To32(self[6])) << 32) | (nat32To64(nat16To32(self[7])) << 48);
+    let c = nat32To64(nat16To32(self[8])) | (nat32To64(nat16To32(self[9])) << 16) | (nat32To64(nat16To32(self[10])) << 32) | (nat32To64(nat16To32(self[11])) << 48);
+    let d = nat32To64(nat16To32(self[12])) | (nat32To64(nat16To32(self[13])) << 16) | (nat32To64(nat16To32(self[14])) << 32) | (nat32To64(nat16To32(self[15])) << 48);
+
+    let p = nat32To64(nat16To32(self[16]));
+    let q = nat32To64(nat16To32(self[17]));
+    let r = nat32To64(nat16To32(self[18]));
 
     let result = a +% b +% d;
 
-    self[0] := b ^ (b >> self[5]);
-    self[1] := c +% (c << self[6]);
-    self[2] := (c <<> self[4]) +% result;
-    self[3] := d +% 1;
+    let na = b ^ (b >> q);
+    let nb = c +% (c << r);
+    let nc = (c <<> p) +% result;
+    let nd = d +% 1;
+
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = Prim.explodeNat64(na);
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = Prim.explodeNat64(nb);
+    let (c0, c1, c2, c3, c4, c5, c6, c7) = Prim.explodeNat64(nc);
+    let (d0, d1, d2, d3, d4, d5, d6, d7) = Prim.explodeNat64(nd);
+    self[0] := nat8To16(a6) << 8 | nat8To16(a7);
+    self[1] := nat8To16(a4) << 8 | nat8To16(a5);
+    self[2] := nat8To16(a2) << 8 | nat8To16(a3);
+    self[3] := nat8To16(a0) << 8 | nat8To16(a1);
+    self[4] := nat8To16(b6) << 8 | nat8To16(b7);
+    self[5] := nat8To16(b4) << 8 | nat8To16(b5);
+    self[6] := nat8To16(b2) << 8 | nat8To16(b3);
+    self[7] := nat8To16(b0) << 8 | nat8To16(b1);
+    self[8] := nat8To16(c6) << 8 | nat8To16(c7);
+    self[9] := nat8To16(c4) << 8 | nat8To16(c5);
+    self[10] := nat8To16(c2) << 8 | nat8To16(c3);
+    self[11] := nat8To16(c0) << 8 | nat8To16(c1);
+    self[12] := nat8To16(d6) << 8 | nat8To16(d7);
+    self[13] := nat8To16(d4) << 8 | nat8To16(d5);
+    self[14] := nat8To16(d2) << 8 | nat8To16(d3);
+    self[15] := nat8To16(d0) << 8 | nat8To16(d1);
 
     result;
   };

--- a/src/Seiran128.mo
+++ b/src/Seiran128.mo
@@ -97,7 +97,7 @@ module Seiran128 {
 
     let na = a ^ (b <<> 29);
     let nb = a ^ (b << 9);
- 
+
     let (a0, a1, a2, a3, a4, a5, a6, a7) = Prim.explodeNat64(na);
     let (b0, b1, b2, b3, b4, b5, b6, b7) = Prim.explodeNat64(nb);
     self[0] := nat8To16(a6) << 8 | nat8To16(a7);

--- a/src/Seiran128.mo
+++ b/src/Seiran128.mo
@@ -18,12 +18,40 @@
 /// Main author: Timo Hanke (timohanke)
 /// Contributors: Andy Gura (AndyGura), react0r-com
 
+import Prim "mo:prim";
+
 module Seiran128 {
+  let nat8To16 = Prim.nat8ToNat16;
+  let nat16To32 = Prim.nat16ToNat32;
+  let nat32To16 = Prim.nat32ToNat16;
+  let nat32To64 = Prim.nat32ToNat64;
+  let nat64To32 = Prim.nat64ToNat32;
+
   /// State of a Seiran128 generator.
-  public type Seiran128 = [var Nat64];
+  /// Layout: two logical `Nat64` words `a` and `b`, each split little-endian
+  /// into four `Nat16` slots — `a = [s0, s1, s2, s3]`, `b = [s4, s5, s6, s7]`,
+  /// where slot `0` and `4` hold the lowest 16 bits.
+  public type Seiran128 = [var Nat16];
 
   /// Default seed for Seiran128 generators.
   public let defaultSeiran128Seed : Nat64 = 0;
+
+  // Reassemble a Nat64 from four little-endian Nat16 slots starting at `base`.
+  func readU64(self : Seiran128, base : Nat) : Nat64 {
+    let w0 = nat32To64(nat16To32(self[base]));
+    let w1 = nat32To64(nat16To32(self[base + 1]));
+    let w2 = nat32To64(nat16To32(self[base + 2]));
+    let w3 = nat32To64(nat16To32(self[base + 3]));
+    w0 | (w1 << 16) | (w2 << 32) | (w3 << 48);
+  };
+
+  // Split a Nat64 into four little-endian Nat16 slots starting at `base`.
+  func writeU64(self : Seiran128, base : Nat, v : Nat64) {
+    self[base] := nat32To16(nat64To32(v & 0xFFFF));
+    self[base + 1] := nat32To16(nat64To32((v >> 16) & 0xFFFF));
+    self[base + 2] := nat32To16(nat64To32((v >> 32) & 0xFFFF));
+    self[base + 3] := nat32To16(nat64To32(v >> 48));
+  };
 
   /// Constructs a Seiran128 generator.
   ///
@@ -33,7 +61,7 @@ module Seiran128 {
   /// let rng = Prng.Seiran128.new();
   /// ```
   public func new(seed : (implicit : (defaultSeiran128Seed : Nat64))) : Seiran128 {
-    let prng : Seiran128 = [var 0, 0];
+    let prng : Seiran128 = [var 0, 0, 0, 0, 0, 0, 0, 0];
     prng.init(seed);
     prng;
   };
@@ -47,8 +75,10 @@ module Seiran128 {
   /// rng.init(0);
   /// ```
   public func init(self : Seiran128, seed : (implicit : (defaultSeiran128Seed : Nat64))) {
-    self[0] := seed *% 6364136223846793005 +% 1442695040888963407;
-    self[1] := self[0] *% 6364136223846793005 +% 1442695040888963407;
+    let a = seed *% 6364136223846793005 +% 1442695040888963407;
+    let b = a *% 6364136223846793005 +% 1442695040888963407;
+    writeU64(self, 0, a);
+    writeU64(self, 4, b);
   };
 
   /// Returns one output and advances the PRNG's state.
@@ -60,13 +90,24 @@ module Seiran128 {
   /// rng.next(); // -> 11_505_474_185_568_172_049
   /// ```
   public func next(self : Seiran128) : Nat64 {
-    let a_ = self[0];
-    let b_ = self[1];
+    let a = nat32To64(nat16To32(self[0])) | (nat32To64(nat16To32(self[1])) << 16) | (nat32To64(nat16To32(self[2])) << 32) | (nat32To64(nat16To32(self[3])) << 48);
+    let b = nat32To64(nat16To32(self[4])) | (nat32To64(nat16To32(self[5])) << 16) | (nat32To64(nat16To32(self[6])) << 32) | (nat32To64(nat16To32(self[7])) << 48);
 
-    let result = (((a_ +% b_) *% 9) <<> 29) +% a_;
+    let result = (((a +% b) *% 9) <<> 29) +% a;
 
-    self[0] := a_ ^ (b_ <<> 29);
-    self[1] := a_ ^ (b_ << 9);
+    let na = a ^ (b <<> 29);
+    let nb = a ^ (b << 9);
+ 
+    let (a0, a1, a2, a3, a4, a5, a6, a7) = Prim.explodeNat64(na);
+    let (b0, b1, b2, b3, b4, b5, b6, b7) = Prim.explodeNat64(nb);
+    self[0] := nat8To16(a6) << 8 | nat8To16(a7);
+    self[1] := nat8To16(a4) << 8 | nat8To16(a5);
+    self[2] := nat8To16(a2) << 8 | nat8To16(a3);
+    self[3] := nat8To16(a0) << 8 | nat8To16(a1);
+    self[4] := nat8To16(b6) << 8 | nat8To16(b7);
+    self[5] := nat8To16(b4) << 8 | nat8To16(b5);
+    self[6] := nat8To16(b2) << 8 | nat8To16(b3);
+    self[7] := nat8To16(b0) << 8 | nat8To16(b1);
 
     result;
   };
@@ -81,8 +122,8 @@ module Seiran128 {
       var i_ : Nat8 = 64;
       while (i_ > 0) {
         if (w & 1 == 1) {
-          t0 ^= self[0];
-          t1 ^= self[1];
+          t0 ^= readU64(self, 0);
+          t1 ^= readU64(self, 4);
         };
 
         w >>= 1;
@@ -91,8 +132,8 @@ module Seiran128 {
       };
     };
 
-    self[0] := t0;
-    self[1] := t1;
+    writeU64(self, 0, t0);
+    writeU64(self, 4, t1);
   };
 
   /// Advances the state 2^32 times.


### PR DESCRIPTION
- `next()` only allocates for the returned value, nothing else
- trade-off: doubles instructions
- **Breaking:** State representation changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version 0.2.0**
  * Allocation-free version released
  * Reduced memory allocations in core operations
  * Updated benchmark results reflecting performance improvements

* **Breaking Changes**
  * State representation format updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/research-ag/prng/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->